### PR TITLE
Inheritance

### DIFF
--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -19,27 +19,33 @@ class WickedPdf
 
       base.class_eval do
         after_action :clean_temp_files
+
+        alias_method :render_without_wicked_pdf, :render
+        alias_method :render, :render_with_wicked_pdf
+
+        alias_method :render_to_string_without_wicked_pdf, :render_to_string
+        alias_method :render_to_string, :render_to_string_with_wicked_pdf
       end
     end
 
-    def render(options = nil, *args, &block)
+    def render_with_wicked_pdf(options = nil, *args, &block)
       if options.is_a?(Hash) && options.key?(:pdf)
         log_pdf_creation
         options[:basic_auth] = set_basic_auth(options)
         make_and_send_pdf(options.delete(:pdf), (WickedPdf.config || {}).merge(options))
       else
-        super(options, *args, &block)
+        render_without_wicked_pdf(options, *args, &block)
       end
     end
 
-    def render_to_string(options = nil, *args, &block)
+    def render_to_string_with_wicked_pdf(options = nil, *args, &block)
       if options.is_a?(Hash) && options.key?(:pdf)
         log_pdf_creation
         options[:basic_auth] = set_basic_auth(options)
         options.delete :pdf
         make_pdf((WickedPdf.config || {}).merge(options))
       else
-        super(options, *args, &block)
+        render_to_string_without_wicked_pdf(options, *args, &block)
       end
     end
 

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -17,7 +17,7 @@ class WickedPdf
 
       def render_with_wicked_pdf(options = nil, *args, &block)
         if use_wicked?(options)
-          _render_pdf(options)
+          wicked_render(options)
         else
           render_without_wicked_pdf(options, *args, &block)
         end
@@ -25,7 +25,7 @@ class WickedPdf
 
       def render_to_string_with_wicked_pdf(options = nil, *args, &block)
         if use_wicked?(options)
-          _wicked_render_to_string(options)
+          wicked_render_to_string(options)
         else
           render_to_string_without_wicked_pdf(options, *args, &block)
         end
@@ -47,7 +47,7 @@ class WickedPdf
 
       def render(options = nil, *args, &block)
         if use_wicked?(options)
-          _render_pdf(options)
+          wicked_render(options)
         else
           super(options, *args, &block)
         end
@@ -55,7 +55,7 @@ class WickedPdf
 
       def render_to_string(options = nil, *args, &block)
         if use_wicked?(options)
-          _wicked_render_to_string(options)
+          wicked_render_to_string(options)
         else
           super(options, *args, &block)
         end
@@ -69,13 +69,13 @@ class WickedPdf
         options.is_a?(Hash) && options.key?(:pdf)
       end
 
-      def _wicked_render(options)
+      def wicked_render(options)
         log_pdf_creation
         options[:basic_auth] = set_basic_auth(options)
         make_and_send_pdf(options.delete(:pdf), (WickedPdf.config || {}).merge(options))
       end
 
-      def _wicked_render_to_string(options)
+      def wicked_render_to_string(options)
         log_pdf_creation
         options[:basic_auth] = set_basic_auth(options)
         options.delete :pdf

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -34,6 +34,7 @@ class WickedPdf
       if options.is_a?(Hash) && options.key?(:pdf)
         log_pdf_creation
         options[:basic_auth] = set_basic_auth(options)
+        make_and_send_pdf(options.delete(:pdf), (WickedPdf.config || {}).merge(options))
       elsif respond_to?(:render_without_wicked_pdf)
         # support alias_method_chain (module included)
         render_without_wicked_pdf(options, *args, &block)

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -1,162 +1,139 @@
 class WickedPdf
   module PdfHelper
-    module RenderWithWicked
-      def self.included(base)
-        # Protect from trying to augment modules that appear
-        # as the result of adding other gems.
-        return if base != ActionController::Base
+    def self.included(base)
+      # Protect from trying to augment modules that appear
+      # as the result of adding other gems.
+      return if base != ActionController::Base
 
-        base.class_eval do
-          include Helpers
-
-          alias_method_chain :render, :wicked_pdf
-          alias_method_chain :render_to_string, :wicked_pdf
-          after_filter :clean_temp_files
-        end
-      end
-
-      def render_with_wicked_pdf(options = nil, *args, &block)
-        if use_wicked?(options)
-          wicked_render(options)
-        else
-          render_without_wicked_pdf(options, *args, &block)
-        end
-      end
-
-      def render_to_string_with_wicked_pdf(options = nil, *args, &block)
-        if use_wicked?(options)
-          wicked_render_to_string(options)
-        else
-          render_to_string_without_wicked_pdf(options, *args, &block)
-        end
+      base.class_eval do
+        alias_method_chain :render, :wicked_pdf
+        alias_method_chain :render_to_string, :wicked_pdf
+        after_filter :clean_temp_files
       end
     end
 
-    module RenderPatch
-      def self.prepended(base)
-        # Protect from trying to augment modules that appear
-        # as the result of adding other gems.
-        return if base != ActionController::Base
+    def self.prepended(base)
+      # Protect from trying to augment modules that appear
+      # as the result of adding other gems.
+      return if base != ActionController::Base
 
-        base.class_eval do
-          include Helpers
-
-          after_action :clean_temp_files
-        end
-      end
-
-      def render(options = nil, *args, &block)
-        if use_wicked?(options)
-          wicked_render(options)
-        else
-          super(options, *args, &block)
-        end
-      end
-
-      def render_to_string(options = nil, *args, &block)
-        if use_wicked?(options)
-          wicked_render_to_string(options)
-        else
-          super(options, *args, &block)
-        end
+      base.class_eval do
+        after_action :clean_temp_files
       end
     end
 
-    module Helpers
-      private
+    def render(options = nil, *args, &block)
+      render_with_wicked_pdf(options, *args, &block)
+    end
 
-      def use_wicked?(options)
-        options.is_a?(Hash) && options.key?(:pdf)
-      end
+    def render_to_string(options = nil, *args, &block)
+      render_to_string_with_wicked_pdf(options, *args, &block)
+    end
 
-      def wicked_render(options)
+    def render_with_wicked_pdf(options = nil, *args, &block)
+      if options.is_a?(Hash) && options.key?(:pdf)
         log_pdf_creation
         options[:basic_auth] = set_basic_auth(options)
-        make_and_send_pdf(options.delete(:pdf), (WickedPdf.config || {}).merge(options))
+      elsif respond_to?(:render_without_wicked_pdf)
+        # support alias_method_chain (module included)
+        render_without_wicked_pdf(options, *args, &block)
+      else
+        # support inheritance (module prepended)
+        method(:render).super_method.call(options, *args, &block)
       end
+    end
 
-      def wicked_render_to_string(options)
+    def render_to_string_with_wicked_pdf(options = nil, *args, &block)
+      if options.is_a?(Hash) && options.key?(:pdf)
         log_pdf_creation
         options[:basic_auth] = set_basic_auth(options)
         options.delete :pdf
         make_pdf((WickedPdf.config || {}).merge(options))
+      elsif respond_to?(:render_to_string_without_wicked_pdf)
+        # support alias_method_chain (module included)
+        render_to_string_without_wicked_pdf(options, *args, &block)
+      else
+        # support inheritance (module prepended)
+        method(:render_to_string).super_method.call(options, *args, &block)
       end
+    end
 
-      def log_pdf_creation
-        logger.info '*' * 15 + 'WICKED' + '*' * 15 if logger && logger.respond_to?(:info)
-      end
+    private
 
-      def set_basic_auth(options = {})
-        options[:basic_auth] ||= WickedPdf.config.fetch(:basic_auth) { false }
-        return unless options[:basic_auth] && request.env['HTTP_AUTHORIZATION']
-        request.env['HTTP_AUTHORIZATION'].split(' ').last
-      end
+    def log_pdf_creation
+      logger.info '*' * 15 + 'WICKED' + '*' * 15 if logger && logger.respond_to?(:info)
+    end
 
-      def clean_temp_files
-        return unless defined?(@hf_tempfiles)
-        @hf_tempfiles.each(&:close!)
-      end
+    def set_basic_auth(options = {})
+      options[:basic_auth] ||= WickedPdf.config.fetch(:basic_auth) { false }
+      return unless options[:basic_auth] && request.env['HTTP_AUTHORIZATION']
+      request.env['HTTP_AUTHORIZATION'].split(' ').last
+    end
 
-      def make_pdf(options = {})
+    def clean_temp_files
+      return unless defined?(@hf_tempfiles)
+      @hf_tempfiles.each(&:close!)
+    end
+
+    def make_pdf(options = {})
+      render_opts = {
+        :template => options[:template],
+        :layout => options[:layout],
+        :formats => options[:formats],
+        :handlers => options[:handlers]
+      }
+      render_opts[:locals] = options[:locals] if options[:locals]
+      render_opts[:file] = options[:file] if options[:file]
+      html_string = render_to_string(render_opts)
+      options = prerender_header_and_footer(options)
+      w = WickedPdf.new(options[:wkhtmltopdf])
+      w.pdf_from_string(html_string, options)
+    end
+
+    def make_and_send_pdf(pdf_name, options = {})
+      options[:wkhtmltopdf] ||= nil
+      options[:layout] ||= false
+      options[:template] ||= File.join(controller_path, action_name)
+      options[:disposition] ||= 'inline'
+      if options[:show_as_html]
         render_opts = {
           :template => options[:template],
           :layout => options[:layout],
           :formats => options[:formats],
-          :handlers => options[:handlers]
+          :handlers => options[:handlers],
+          :content_type => 'text/html'
         }
         render_opts[:locals] = options[:locals] if options[:locals]
         render_opts[:file] = options[:file] if options[:file]
-        html_string = render_to_string(render_opts)
-        options = prerender_header_and_footer(options)
-        w = WickedPdf.new(options[:wkhtmltopdf])
-        w.pdf_from_string(html_string, options)
+        render(render_opts)
+      else
+        pdf_content = make_pdf(options)
+        File.open(options[:save_to_file], 'wb') { |file| file << pdf_content } if options[:save_to_file]
+        send_data(pdf_content, :filename => pdf_name + '.pdf', :type => 'application/pdf', :disposition => options[:disposition]) unless options[:save_only]
       end
+    end
 
-      def make_and_send_pdf(pdf_name, options = {})
-        options[:wkhtmltopdf] ||= nil
-        options[:layout] ||= false
-        options[:template] ||= File.join(controller_path, action_name)
-        options[:disposition] ||= 'inline'
-        if options[:show_as_html]
-          render_opts = {
-            :template => options[:template],
-            :layout => options[:layout],
-            :formats => options[:formats],
-            :handlers => options[:handlers],
-            :content_type => 'text/html'
-          }
-          render_opts[:locals] = options[:locals] if options[:locals]
-          render_opts[:file] = options[:file] if options[:file]
-          render(render_opts)
-        else
-          pdf_content = make_pdf(options)
-          File.open(options[:save_to_file], 'wb') { |file| file << pdf_content } if options[:save_to_file]
-          send_data(pdf_content, :filename => pdf_name + '.pdf', :type => 'application/pdf', :disposition => options[:disposition]) unless options[:save_only]
-        end
+    # Given an options hash, prerenders content for the header and footer sections
+    # to temp files and return a new options hash including the URLs to these files.
+    def prerender_header_and_footer(options)
+      [:header, :footer].each do |hf|
+        next unless options[hf] && options[hf][:html] && options[hf][:html][:template]
+        @hf_tempfiles = [] unless defined?(@hf_tempfiles)
+        @hf_tempfiles.push(tf = WickedPdfTempfile.new("wicked_#{hf}_pdf.html"))
+        options[hf][:html][:layout] ||= options[:layout]
+        render_opts = {
+          :template => options[hf][:html][:template],
+          :layout => options[hf][:html][:layout],
+          :formats => options[hf][:html][:formats],
+          :handlers => options[hf][:html][:handlers]
+        }
+        render_opts[:locals] = options[hf][:html][:locals] if options[hf][:html][:locals]
+        render_opts[:file] = options[hf][:html][:file] if options[:file]
+        tf.write render_to_string(render_opts)
+        tf.flush
+        options[hf][:html][:url] = "file:///#{tf.path}"
       end
-
-      # Given an options hash, prerenders content for the header and footer sections
-      # to temp files and return a new options hash including the URLs to these files.
-      def prerender_header_and_footer(options)
-        [:header, :footer].each do |hf|
-          next unless options[hf] && options[hf][:html] && options[hf][:html][:template]
-          @hf_tempfiles = [] unless defined?(@hf_tempfiles)
-          @hf_tempfiles.push(tf = WickedPdfTempfile.new("wicked_#{hf}_pdf.html"))
-          options[hf][:html][:layout] ||= options[:layout]
-          render_opts = {
-            :template => options[hf][:html][:template],
-            :layout => options[hf][:html][:layout],
-            :formats => options[hf][:html][:formats],
-            :handlers => options[hf][:html][:handlers]
-          }
-          render_opts[:locals] = options[hf][:html][:locals] if options[hf][:html][:locals]
-          render_opts[:file] = options[hf][:html][:file] if options[:file]
-          tf.write render_to_string(render_opts)
-          tf.flush
-          options[hf][:html][:url] = "file:///#{tf.path}"
-        end
-        options
-      end
+      options
     end
   end
 end

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -1,130 +1,162 @@
 class WickedPdf
   module PdfHelper
-    def self.included(base)
-      # Protect from trying to augment modules that appear
-      # as the result of adding other gems.
-      return if base != ActionController::Base
+    module RenderWithWicked
+      def self.included(base)
+        # Protect from trying to augment modules that appear
+        # as the result of adding other gems.
+        return if base != ActionController::Base
 
-      base.class_eval do
-        alias_method_chain :render, :wicked_pdf
-        alias_method_chain :render_to_string, :wicked_pdf
-        after_filter :clean_temp_files
+        base.include(Helpers)
+
+        base.class_eval do
+          alias_method_chain :render, :wicked_pdf
+          alias_method_chain :render_to_string, :wicked_pdf
+          after_filter :clean_temp_files
+        end
+      end
+
+      def render_with_wicked_pdf(options = nil, *args, &block)
+        if use_wicked?(options)
+          _render_pdf(options)
+        else
+          render_without_wicked_pdf(options, *args, &block)
+        end
+      end
+
+      def render_to_string_with_wicked_pdf(options = nil, *args, &block)
+        if use_wicked?(options)
+          _wicked_render_to_string(options)
+        else
+          render_to_string_without_wicked_pdf(options, *args, &block)
+        end
       end
     end
 
-    def self.prepended(base)
-      # Protect from trying to augment modules that appear
-      # as the result of adding other gems.
-      return if base != ActionController::Base
+    module RenderPatch
+      def self.prepended(base)
+        # Protect from trying to augment modules that appear
+        # as the result of adding other gems.
+        return if base != ActionController::Base
 
-      base.class_eval do
-        after_action :clean_temp_files
+        base.include(Helpers)
 
-        alias_method :render_without_wicked_pdf, :render
-        alias_method :render, :render_with_wicked_pdf
+        base.class_eval do
+          after_action :clean_temp_files
+        end
+      end
 
-        alias_method :render_to_string_without_wicked_pdf, :render_to_string
-        alias_method :render_to_string, :render_to_string_with_wicked_pdf
+      def render(options = nil, *args, &block)
+        if use_wicked?(options)
+          _render_pdf(options)
+        else
+          super(options, *args, &block)
+        end
+      end
+
+      def render_to_string(options = nil, *args, &block)
+        if use_wicked?(options)
+          _wicked_render_to_string(options)
+        else
+          super(options, *args, &block)
+        end
       end
     end
 
-    def render_with_wicked_pdf(options = nil, *args, &block)
-      if options.is_a?(Hash) && options.key?(:pdf)
+    module Helpers
+      private
+
+      def use_wicked?(options)
+        options.is_a?(Hash) && options.key?(:pdf)
+      end
+
+      def _wicked_render(options)
         log_pdf_creation
         options[:basic_auth] = set_basic_auth(options)
         make_and_send_pdf(options.delete(:pdf), (WickedPdf.config || {}).merge(options))
-      else
-        render_without_wicked_pdf(options, *args, &block)
       end
-    end
 
-    def render_to_string_with_wicked_pdf(options = nil, *args, &block)
-      if options.is_a?(Hash) && options.key?(:pdf)
+      def _wicked_render_to_string(options)
         log_pdf_creation
         options[:basic_auth] = set_basic_auth(options)
         options.delete :pdf
         make_pdf((WickedPdf.config || {}).merge(options))
-      else
-        render_to_string_without_wicked_pdf(options, *args, &block)
       end
-    end
 
-    private
+      def log_pdf_creation
+        logger.info '*' * 15 + 'WICKED' + '*' * 15 if logger && logger.respond_to?(:info)
+      end
 
-    def log_pdf_creation
-      logger.info '*' * 15 + 'WICKED' + '*' * 15 if logger && logger.respond_to?(:info)
-    end
+      def set_basic_auth(options = {})
+        options[:basic_auth] ||= WickedPdf.config.fetch(:basic_auth) { false }
+        return unless options[:basic_auth] && request.env['HTTP_AUTHORIZATION']
+        request.env['HTTP_AUTHORIZATION'].split(' ').last
+      end
 
-    def set_basic_auth(options = {})
-      options[:basic_auth] ||= WickedPdf.config.fetch(:basic_auth) { false }
-      return unless options[:basic_auth] && request.env['HTTP_AUTHORIZATION']
-      request.env['HTTP_AUTHORIZATION'].split(' ').last
-    end
+      def clean_temp_files
+        return unless defined?(@hf_tempfiles)
+        @hf_tempfiles.each(&:close!)
+      end
 
-    def clean_temp_files
-      return unless defined?(@hf_tempfiles)
-      @hf_tempfiles.each(&:close!)
-    end
-
-    def make_pdf(options = {})
-      render_opts = {
-        :template => options[:template],
-        :layout => options[:layout],
-        :formats => options[:formats],
-        :handlers => options[:handlers]
-      }
-      render_opts[:locals] = options[:locals] if options[:locals]
-      render_opts[:file] = options[:file] if options[:file]
-      html_string = render_to_string(render_opts)
-      options = prerender_header_and_footer(options)
-      w = WickedPdf.new(options[:wkhtmltopdf])
-      w.pdf_from_string(html_string, options)
-    end
-
-    def make_and_send_pdf(pdf_name, options = {})
-      options[:wkhtmltopdf] ||= nil
-      options[:layout] ||= false
-      options[:template] ||= File.join(controller_path, action_name)
-      options[:disposition] ||= 'inline'
-      if options[:show_as_html]
+      def make_pdf(options = {})
         render_opts = {
           :template => options[:template],
           :layout => options[:layout],
           :formats => options[:formats],
-          :handlers => options[:handlers],
-          :content_type => 'text/html'
+          :handlers => options[:handlers]
         }
         render_opts[:locals] = options[:locals] if options[:locals]
         render_opts[:file] = options[:file] if options[:file]
-        render(render_opts)
-      else
-        pdf_content = make_pdf(options)
-        File.open(options[:save_to_file], 'wb') { |file| file << pdf_content } if options[:save_to_file]
-        send_data(pdf_content, :filename => pdf_name + '.pdf', :type => 'application/pdf', :disposition => options[:disposition]) unless options[:save_only]
+        html_string = render_to_string(render_opts)
+        options = prerender_header_and_footer(options)
+        w = WickedPdf.new(options[:wkhtmltopdf])
+        w.pdf_from_string(html_string, options)
       end
-    end
 
-    # Given an options hash, prerenders content for the header and footer sections
-    # to temp files and return a new options hash including the URLs to these files.
-    def prerender_header_and_footer(options)
-      [:header, :footer].each do |hf|
-        next unless options[hf] && options[hf][:html] && options[hf][:html][:template]
-        @hf_tempfiles = [] unless defined?(@hf_tempfiles)
-        @hf_tempfiles.push(tf = WickedPdfTempfile.new("wicked_#{hf}_pdf.html"))
-        options[hf][:html][:layout] ||= options[:layout]
-        render_opts = {
-          :template => options[hf][:html][:template],
-          :layout => options[hf][:html][:layout],
-          :formats => options[hf][:html][:formats],
-          :handlers => options[hf][:html][:handlers]
-        }
-        render_opts[:locals] = options[hf][:html][:locals] if options[hf][:html][:locals]
-        render_opts[:file] = options[hf][:html][:file] if options[:file]
-        tf.write render_to_string(render_opts)
-        tf.flush
-        options[hf][:html][:url] = "file:///#{tf.path}"
+      def make_and_send_pdf(pdf_name, options = {})
+        options[:wkhtmltopdf] ||= nil
+        options[:layout] ||= false
+        options[:template] ||= File.join(controller_path, action_name)
+        options[:disposition] ||= 'inline'
+        if options[:show_as_html]
+          render_opts = {
+            :template => options[:template],
+            :layout => options[:layout],
+            :formats => options[:formats],
+            :handlers => options[:handlers],
+            :content_type => 'text/html'
+          }
+          render_opts[:locals] = options[:locals] if options[:locals]
+          render_opts[:file] = options[:file] if options[:file]
+          render(render_opts)
+        else
+          pdf_content = make_pdf(options)
+          File.open(options[:save_to_file], 'wb') { |file| file << pdf_content } if options[:save_to_file]
+          send_data(pdf_content, :filename => pdf_name + '.pdf', :type => 'application/pdf', :disposition => options[:disposition]) unless options[:save_only]
+        end
       end
-      options
+
+      # Given an options hash, prerenders content for the header and footer sections
+      # to temp files and return a new options hash including the URLs to these files.
+      def prerender_header_and_footer(options)
+        [:header, :footer].each do |hf|
+          next unless options[hf] && options[hf][:html] && options[hf][:html][:template]
+          @hf_tempfiles = [] unless defined?(@hf_tempfiles)
+          @hf_tempfiles.push(tf = WickedPdfTempfile.new("wicked_#{hf}_pdf.html"))
+          options[hf][:html][:layout] ||= options[:layout]
+          render_opts = {
+            :template => options[hf][:html][:template],
+            :layout => options[hf][:html][:layout],
+            :formats => options[hf][:html][:formats],
+            :handlers => options[hf][:html][:handlers]
+          }
+          render_opts[:locals] = options[hf][:html][:locals] if options[hf][:html][:locals]
+          render_opts[:file] = options[hf][:html][:file] if options[:file]
+          tf.write render_to_string(render_opts)
+          tf.flush
+          options[hf][:html][:url] = "file:///#{tf.path}"
+        end
+        options
+      end
     end
   end
 end

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -6,9 +6,9 @@ class WickedPdf
         # as the result of adding other gems.
         return if base != ActionController::Base
 
-        base.include(Helpers)
-
         base.class_eval do
+          include Helpers
+
           alias_method_chain :render, :wicked_pdf
           alias_method_chain :render_to_string, :wicked_pdf
           after_filter :clean_temp_files
@@ -38,9 +38,9 @@ class WickedPdf
         # as the result of adding other gems.
         return if base != ActionController::Base
 
-        base.include(Helpers)
-
         base.class_eval do
+          include Helpers
+
           after_action :clean_temp_files
         end
       end

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -19,38 +19,27 @@ class WickedPdf
 
       base.class_eval do
         after_action :clean_temp_files
-
-        alias_method :render_without_wicked_pdf, :render
-        alias_method :render_to_string_without_wicked_pdf, :render_to_string
-
-        def render(options = nil, *args, &block)
-          render_with_wicked_pdf(options, *args, &block)
-        end
-
-        def render_to_string(options = nil, *args, &block)
-          render_to_string_with_wicked_pdf(options, *args, &block)
-        end
       end
     end
 
-    def render_with_wicked_pdf(options = nil, *args, &block)
+    def render(options = nil, *args, &block)
       if options.is_a?(Hash) && options.key?(:pdf)
         log_pdf_creation
         options[:basic_auth] = set_basic_auth(options)
         make_and_send_pdf(options.delete(:pdf), (WickedPdf.config || {}).merge(options))
       else
-        render_without_wicked_pdf(options, *args, &block)
+        super(options, *args, &block)
       end
     end
 
-    def render_to_string_with_wicked_pdf(options = nil, *args, &block)
+    def render_to_string(options = nil, *args, &block)
       if options.is_a?(Hash) && options.key?(:pdf)
         log_pdf_creation
         options[:basic_auth] = set_basic_auth(options)
         options.delete :pdf
         make_pdf((WickedPdf.config || {}).merge(options))
       else
-        render_to_string_without_wicked_pdf(options, *args, &block)
+        super(options, *args, &block)
       end
     end
 

--- a/lib/wicked_pdf/railtie.rb
+++ b/lib/wicked_pdf/railtie.rb
@@ -9,7 +9,7 @@ class WickedPdf
 
       class WickedRailtie < Rails::Railtie
         initializer 'wicked_pdf.register' do |_app|
-          ActionController::Base.send :prepend, PdfHelper::RenderPatch
+          ActionController::Base.send :prepend, PdfHelper
           ActionView::Base.send :include, WickedPdfHelper::Assets
         end
       end
@@ -18,7 +18,7 @@ class WickedPdf
 
       class WickedRailtie < Rails::Railtie
         initializer 'wicked_pdf.register' do |_app|
-          ActionController::Base.send :include, PdfHelper::RenderWithWicked
+          ActionController::Base.send :include, PdfHelper
           ActionView::Base.send :include, WickedPdfHelper::Assets
         end
       end
@@ -27,7 +27,7 @@ class WickedPdf
 
       class WickedRailtie < Rails::Railtie
         initializer 'wicked_pdf.register' do |_app|
-          ActionController::Base.send :include, PdfHelper::RenderWithWicked
+          ActionController::Base.send :include, PdfHelper
           if Rails::VERSION::MINOR > 0 && Rails.configuration.assets.enabled
             ActionView::Base.send :include, WickedPdfHelper::Assets
           else
@@ -39,7 +39,7 @@ class WickedPdf
     elsif Rails::VERSION::MAJOR == 2
 
       unless ActionController::Base.instance_methods.include? 'render_with_wicked_pdf'
-        ActionController::Base.send :include, PdfHelper::RenderWithWicked
+        ActionController::Base.send :include, PdfHelper
       end
       unless ActionView::Base.instance_methods.include? 'wicked_pdf_stylesheet_link_tag'
         ActionView::Base.send :include, WickedPdfHelper

--- a/lib/wicked_pdf/railtie.rb
+++ b/lib/wicked_pdf/railtie.rb
@@ -9,7 +9,7 @@ class WickedPdf
 
       class WickedRailtie < Rails::Railtie
         initializer 'wicked_pdf.register' do |_app|
-          ActionController::Base.send :prepend, PdfHelper
+          ActionController::Base.send :prepend, PdfHelper::RenderPatch
           ActionView::Base.send :include, WickedPdfHelper::Assets
         end
       end
@@ -18,7 +18,7 @@ class WickedPdf
 
       class WickedRailtie < Rails::Railtie
         initializer 'wicked_pdf.register' do |_app|
-          ActionController::Base.send :include, PdfHelper
+          ActionController::Base.send :include, PdfHelper::RenderWithWicked
           ActionView::Base.send :include, WickedPdfHelper::Assets
         end
       end
@@ -27,7 +27,7 @@ class WickedPdf
 
       class WickedRailtie < Rails::Railtie
         initializer 'wicked_pdf.register' do |_app|
-          ActionController::Base.send :include, PdfHelper
+          ActionController::Base.send :include, PdfHelper::RenderWithWicked
           if Rails::VERSION::MINOR > 0 && Rails.configuration.assets.enabled
             ActionView::Base.send :include, WickedPdfHelper::Assets
           else
@@ -39,7 +39,7 @@ class WickedPdf
     elsif Rails::VERSION::MAJOR == 2
 
       unless ActionController::Base.instance_methods.include? 'render_with_wicked_pdf'
-        ActionController::Base.send :include, PdfHelper
+        ActionController::Base.send :include, PdfHelper::RenderWithWicked
       end
       unless ActionView::Base.instance_methods.include? 'wicked_pdf_stylesheet_link_tag'
         ActionView::Base.send :include, WickedPdfHelper

--- a/test/functional/pdf_helper_test.rb
+++ b/test/functional/pdf_helper_test.rb
@@ -68,10 +68,14 @@ class PdfHelperTest < ActionController::TestCase
       ActionController::Base.prepend(SomePatch)
       ActionController::Base.prepend(::WickedPdf::PdfHelper)
 
-      # test that calling render does not trigger infinite loop
-      ac = ActionController::Base.new
-
       begin
+        # test that wicked's render method is actually called
+        ac = ActionController::Base.new
+        ac.expects(:render_with_wicked_pdf)
+        ac.render(:cats)
+
+        # test that calling render does not trigger infinite loop
+        ac = ActionController::Base.new
         assert_equal [:base, :patched], ac.render(:cats)
       rescue SystemStackError
         assert_equal true, false # force spec failure
@@ -79,11 +83,6 @@ class PdfHelperTest < ActionController::TestCase
         ActionController.send(:remove_const, :Base)
         ActionController.const_set(:Base, OriginalBase)
       end
-
-      # test that wicked's render method is actually called
-      ac = ActionController::Base.new
-      ac.expects(:render_with_wicked_pdf)
-      ac.render(:cats)
     end
   end
 end

--- a/test/functional/pdf_helper_test.rb
+++ b/test/functional/pdf_helper_test.rb
@@ -8,7 +8,29 @@ module ActionController
   end
 end
 
+module ActionControllerMock
+  class Base
+    def render(_)
+      [:base]
+    end
+
+    def render_to_string
+    end
+
+    def self.after_action(_)
+    end
+  end
+end
+
 class PdfHelperTest < ActionController::TestCase
+  module SomePatch
+    def render(_)
+      super.tap do |s|
+        s << :patched
+      end
+    end
+  end
+
   def setup
     @ac = ActionController::Base.new
   end
@@ -21,5 +43,29 @@ class PdfHelperTest < ActionController::TestCase
     options = @ac.send(:prerender_header_and_footer,
                        :header => { :html => { :template => 'hf.html.erb' } })
     assert_match %r{^file:\/\/\/.*wicked_header_pdf.*\.html}, options[:header][:html][:url]
+  end
+
+  test 'should not interfere with already prepended patches' do
+    # Emulate railtie
+    if Rails::VERSION::MAJOR >= 5
+      OriginalBase = ActionController::Base
+      ActionController.send(:remove_const, :Base)
+      ActionController.const_set(:Base, ActionControllerMock::Base)
+
+      # Emulate another gem being loaded before wicked
+      ActionController::Base.prepend(SomePatch)
+      ActionController::Base.prepend(::WickedPdf::PdfHelper)
+
+      ac = ActionController::Base.new
+
+      begin
+        assert_equal ac.render(:cats), [:base, :patched]
+      rescue SystemStackError
+        assert_equal true, false # force spec failure
+      ensure
+        ActionController.send(:remove_const, :Base)
+        ActionController.const_set(:Base, OriginalBase)
+      end
+    end
   end
 end


### PR DESCRIPTION
After upgrading to rails 5 we found that the way wicked_pdf prepends `ActionController::Base#render` causes an infinite loop when combined with another gem prepending render.

I believe our issue is generally related to https://github.com/mileszs/wicked_pdf/issues/111, though this PR focuses on prepend behavior.

The loop happens because wicked_pdf is not using the traditional prepend inheritance pattern, which looks like this

``` ruby
class Base
  def render
  end
end

class Patch
  def render
    patched_behavior
    super
  end
end

Base.prepend(Patch)
```

Instead, PdfHelper aliases the current render method away, then defines its own render method _on the base class_, which then calls the new render_with_wicked_pdf method.

If any other gem prepends its own render method using the inheritance pattern, before wicked_pdf prepends PdfHelper, this happens:
1. ActionController::Base is loaded, and its render method is defined.
2. OtherGem has its patch prepended, putting its render method in front of ActionController::Bases render method in the lookup chain. (OtherGem calls super to get to the original render method)
3. wicked_pdf has PdfHelper prepended:
4. PdfHelper.prepended aliases OtherGem#render to render_without_wicked.
5. PdfHelper.prepended re-defines render on ActionController::Base using base_eval.
6. render is called from a controller action:
7. OtherGem#render is called, and it calls super
8. PdfHelper's version of #render is called, and it calls render_with_wicked
9. render_with_wicked calls render_without_wicked
10. render_without_wicked is an alias for OtherGem#render
11. infinite loop.

I've included a test that demonstrates this behavior. Its quite ugly as it has to replicate what railtie.rb does after another gem is prepended, which i couldn't figure out how to do since all of wicked is loaded before the tests run, so my solution was to just demonstrate it with a mock ActionController::Base class.

I'm new to test-unit so please let me know if these tests can be cleaned up.
